### PR TITLE
[MAIN] DOCS | Changing the command to run the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The backend was built using .NET Core version 7
 - While running the backend, you can now consume all the API data through the frontend of the application. Go to frontend/lifecare-front folter and just run the following commands:
 ```sh
 npm install
-npm start
+npm run dev
 ```
 ### [Tip] - How to Run MySql in a Docker Container (Step by Step) 
 Use docker to run the database. 


### PR DESCRIPTION
# Description

Changing the documentation command to run the frontend - from 'npm start' (wrong command) to 'npm run dev'

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change is/requires a documentation update